### PR TITLE
FIX: Видимость иконки почты для белой темы

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I'm a full stack QA from Syberia. I'm doing manual and automated testing of the 
 <p align="left">
 <a href="https://instagram.com/slav.qa" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/instagram.svg" alt="slav.qa" height="30" width="40" /></a>
 <a href="https://t.me/SZhavoronkov24" target="blank"><img align="center" src="https://cdn-icons-png.flaticon.com/128/3536/3536661.png" alt="SZhavoronkov24" height="30" width="30" /></a>
-<a href="mailto:sl.zhavoronkov@yandex.ru" target="blank"><img align="center" src="https://icon-library.com/images/white-mail-icon-png/white-mail-icon-png-13.jpg" alt="slav.qa" height="30" weight="40" /></a>
+<a href="mailto:sl.zhavoronkov@yandex.ru" target="blank"><img align="center" src="https://cdn-icons-png.flaticon.com/512/526/526901.png" alt="slav.qa" height="35" style="margin:5px"/></a>
 
 
 </p>


### PR DESCRIPTION
Белую иконку не видно на стандартной теме оформления GitHub
![image](https://github.com/user-attachments/assets/764d2707-c462-4a20-bb0b-9e808faa10c1)

После правки будет отображаться корректно
![image](https://github.com/user-attachments/assets/995bbbaa-d080-48cc-a0a9-78c3690fcfe1)
